### PR TITLE
Minimum changes to build on clang-11.0.3 (clang-1103.0.32.62)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ CFLAGS += -std=gnu11 -pedantic -Wall -Wextra \
 	-Wno-unused-label -Wno-unused-function -Wcast-align -Wpointer-arith -Wbad-function-cast \
 	-Wstrict-overflow=5 -Wstrict-prototypes -Winline -Wundef -Wnested-externs \
 	-Wcast-qual -Wshadow -Wunreachable-code -Wfloat-equal \
-	-Wstrict-aliasing=2 -Wredundant-decls -Wold-style-definition
+	-Wstrict-aliasing=2 -Wredundant-decls -Wold-style-definition \
+	-Wno-format-nonliteral -Wno-deprecated-declarations -Wno-gnu-empty-initializer \
+
 LDFLAGS = -pthread
 SOURCES = main.c con_queue.c log.c device_handler.c event_thread.c config.c connection.c \
 	data_channel.c snmp.c

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ image data within the same (original) connection. But only on Windows... Well, n
 
 # Installation
 ```
-git clone https://github.com/darsto/brother-scanner-driver.git
+git clone --recurse-submodules https://github.com/darsto/brother-scanner-driver.git
 cd brother-scanner-driver
 make
 cd out
 vi ./brother.config
-chmod +x ./scanhook.sh
+chmod +x ./scanhook.sh      # if it is not already
 ../build/brother-scand
 ```
 

--- a/data_channel.c
+++ b/data_channel.c
@@ -13,6 +13,7 @@
 #include <memory.h>
 #include <zconf.h>
 #include <errno.h>
+#include <limits.h>
 #include "data_channel.h"
 
 #include "connection.h"
@@ -538,7 +539,7 @@ exchange_params2(struct data_channel *data_channel)
 
         strncpy(param->value, (const char *) data_channel->buf,
                 sizeof(param->value));
-        param->value[sizeof(param->value)] = 0;
+        param->value[sizeof(param->value) - 1] = 0; // the last byte of a 16-char buffer is (size - 1) = 15
     }
 
     param = get_scan_param_by_id(data_channel, 'A');

--- a/device_handler.c
+++ b/device_handler.c
@@ -143,7 +143,7 @@ register_scanner_driver(struct device *dev, char local_ip[16], bool enabled)
 struct device *
 device_handler_add_device(struct device_config *config)
 {
-    struct device *dev;
+    struct device *dev = NULL;
     struct brother_conn *conn;
     int status, rc, i;
     char local_ip[16];

--- a/event_thread.c
+++ b/event_thread.c
@@ -182,7 +182,7 @@ event_thread_create(const char *name, void (*update_cb)(void *),
     thread_id = atomic_fetch_add(&g_thread_cnt, 1);
     if (thread_id >= MAX_EVENT_THREADS) {
         LOG_FATAL("Reached the thread limit (%d).\n", MAX_EVENT_THREADS);
-        goto name_err;
+        goto err;  // cannot goto name_err because it frees thread->name, but thread is not yet initialized
     }
 
     thread = &g_threads[thread_id];


### PR DESCRIPTION
## Minimum changes to build on clang-11.0.3 (clang-1103.0.32.62) for x86_64-apple-darwin19.5.0
 * minimal customization of stock Apple:
    * install XCode from Apple App Store (XCode 11.6 onto MacOS-10.15.6 "Catalina")
 * clone the repo per the README (see updated "--recurse-submodules")
 * build warning-free per the README

*NOTE*: I'm not a fan of cmake-ing the world, my personal experience hasn't lead to great `cmake` support experiences, I'd rather `bazelify`-the-world personally or drop back to `autotools` for most compatibility :)  For this reason, I see @rumpeltux's https://github.com/darsto/brother-scand/pull/6 but would prefer autotools or bazel to cmake.

To avoid resistance based on replacing the build tool, I've cut a smaller PR to simply update this repo to the minimum required to build.

### Apple's Clang-11.0.3 is:
```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 11.0.3 (clang-1103.0.32.62)
Target: x86_64-apple-darwin19.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```